### PR TITLE
Add fast emoji response feature for permission prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,12 @@ oauth_config:
 settings:
   event_subscriptions:
     bot_events:
+      - app_mention
       - message.channels
       - message.groups
       - message.im
       - message.mpim
+      - reaction_added
   interactivity:
     is_enabled: false
   org_deploy_enabled: false
@@ -152,19 +154,22 @@ After adding `~/.claude/claude-slack/bin` to your PATH:
 
 ## Troubleshooting
 
-### Socket Starvation Issue
+### Quick Emoji Responses
 
-**Symptom**: Message sent to Slack but no green checkmark appears, Claude doesn't respond
+Permission prompts now show 1️⃣ 2️⃣ 3️⃣ emoji reactions - just tap to respond! Requires:
+- `reactions:read` scope (included in manifest above)
+- `reaction_added` event subscription (included in manifest above)
 
-**Root Cause**: Socket communication starvation - the connection between Slack listener and Claude session becomes unresponsive
+### Socket Starvation Issue (FIXED)
 
-**Workaround**:
-- Send an @ mention to your bot.  Make the @ mention the FIRST word in your message (e.g., `@claudebot your message here`)
-- The @ mention "wakes up" the listener and re-establishes communication
-- After the @ mention, regular messages should work again
-- Occasionally, its flakey enough that you need to copy paste your message and send it again to wake it up.
+**Previous issue**: Messages sometimes not received, requiring @ mentions to "wake up" the listener.
 
-**Long-term solution**: Under investigation
+**Solution applied**:
+- Increased socket backlog from 1 to 128 connections
+- Added retry logic with exponential backoff
+- Added proper socket timeout handling
+
+If you still experience issues, ensure your Slack app has all the scopes and events from the manifest above.
 
 ### Checking Logs
 
@@ -261,8 +266,8 @@ This integration uses three Claude Code hooks:
 
 ## Known Limitations
 
-- Socket starvation issue requires @ mention workaround
-- ~~Notifications from Claude aren't printing full content~~ **SOLVED!** ✅
+- ~~Socket starvation issue requires @ mention workaround~~ **FIXED!**
+- ~~Notifications from Claude aren't printing full content~~ **FIXED!**
   - PreToolUse hook now provides complete context for all permission requests
   - See actual bash commands, file contents, and tool parameters before approving
 


### PR DESCRIPTION
## Summary

Enables users to tap emoji reactions (1️⃣ 2️⃣ 3️⃣) instead of typing numbers to respond to permission prompts. Also includes the socket starvation fix.

### New Features

- **Auto-add emoji reactions**: Permission prompts now show 1️⃣ 2️⃣ 3️⃣ reactions
- **Tap to respond**: Tapping an emoji sends the corresponding number to Claude
- **Shortcuts**: 👍→1 (approve), 👎→3 (deny), ✅→1, ❌→3
- **Confirmation**: ✅ checkmark added when reaction is processed

### Bug Fixes

- **Socket starvation fixed**: Increased backlog from 1→128, added retry logic with exponential backoff
- **Emoji ordering**: Small delay ensures reactions appear as 1, 2, 3 (not scrambled)

### Documentation

- Updated Slack app manifest with `reaction_added` event and `app_mention`
- Updated troubleshooting section marking socket starvation as fixed
- Added quick emoji response documentation

## Files Changed

| File | Changes |
|------|---------|
| `core/slack_listener.py` | Implement `handle_reaction()` with proper Slack Bolt signature |
| `hooks/on_notification.py` | Auto-add 1️⃣2️⃣3️⃣ reactions to permission prompts |
| `README.md` | Update manifest, docs, mark issues as fixed |

## Setup Required

After merging, existing Slack apps need to add:
1. `reaction_added` to Event Subscriptions → Bot Events
2. Reinstall app to workspace

## Testing

- Verified emoji reactions appear in correct order (1, 2, 3)
- Verified tapping emoji sends correct response to Claude
- Verified confirmation checkmark appears after tap